### PR TITLE
Don't use `case_when()` for simple if/else

### DIFF
--- a/R/prepare.R
+++ b/R/prepare.R
@@ -552,11 +552,13 @@ prepare_table <- function(
     )))) |>
     dplyr::arrange(timepoint) |>
     dplyr::mutate(
-      value_for_history = dplyr::case_when(
-        plot_value_type == "value" ~ as.numeric(value),
-        plot_value_type == "delta" ~
-          as.numeric(value) - dplyr::lag(as.numeric(value))
-      )
+      value_for_history = if (plot_value_type == "value") {
+        as.numeric(value)
+      } else if (plot_value_type == "delta") {
+        as.numeric(value) - dplyr::lag(as.numeric(value))
+      } else {
+        NA_real_
+      }
     ) |>
     dplyr::summarise(
       item_order_final = min(item_order_final),


### PR DESCRIPTION
Hi there, we are working on the next version of dplyr and your package was flagged in our reverse dependency checks.

Your package uses `case_when()` in a way that is more suitable for a simple if/else. We have started warning on these scenarios, and that causes your package to fail.

dplyr will be released on January 31, 2026. If you could please send an update of your package to CRAN before then, that would help us out a lot! Thanks!